### PR TITLE
fixed bug in getResponseHeader

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -154,7 +154,7 @@ var Request = module.exports = function () {
   this.getResponseHeader = function (key) {
     if (!mock) return request.getResponseHeader();
 
-    return mock.headers[key];
+    return mock.response.headers[key];
   };
 
   /**


### PR DESCRIPTION
When I attempted to this with the superagent library I ran into issue which ultimately lead me to what I believe is an issue with the `getResponseHeader()` method. The ` getResponseHeader()` method is trying to get the header from `mock.headers` instead of `mock.response.headers` (like the `getAllResponseHeaders()` method is).

It would be nice to create and push a new bower tag when you merge this so I don't have to be worried about overwrite my modified copy I currently have.