### PR TITLE
added support for npm installation (#10)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,10 @@
+test/*
+.bowerrc
+.editorconfig
+.gitignore
+.jshintrc
+.npmignore
+backend.js
+bower.json
+gulpfile.js
+karma.conf.js

--- a/README.md
+++ b/README.md
@@ -20,6 +20,30 @@ called to allow your request to pass through.
 Originally, this project was started out of boredom! Then one day I found a need
 to stub responses in Web Workers, so I decided to revisit it and so it is.
 
+## Installation
+
+### NPM
+
+```
+npm install mocked-backend
+```
+
+Then just require:
+
+```javascript
+var backend = require('mocked-backend');
+```
+
+**Note that this only works in the browser (using something like browserify)**
+
+### Bower
+
+```
+bower install backend
+```
+
+You just need to include the `backend.js` file that comes with the bower install.
+
 ## Examples
 
 Stub a response:

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -32,6 +32,10 @@ Mock.prototype.match = function match (method, url, data, headers) {
     if (this.method === method.toUpperCase()) {
       // can't do equals(), as jQuery will add extra headers
       if (!this.headers || _.contains(headers, this.headers)) {
+        if (typeof data === 'string') {
+            data = JSON.parse(data);
+        }
+
         if (!this.data || _.isEqual(this.data, data)) {
           return true;
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "backend",
+  "name": "mocked-backend",
   "version": "0.2.2",
+  "main": "./index.js",
   "devDependencies": {
     "gulp": "^3.8.8",
     "browserify": "^6.0.3",


### PR DESCRIPTION
Used the name `mocked-backend` for npm but left the bower name the same just so existing stuff won't break.  Note sure if you want to also change the bower name too.