### PR TITLE
Enable Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-test/bower_components
 node_modules
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+sudo: false
+node_js:
+  - 0.12

--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,6 @@
 {
   "name": "backend",
   "version": "0.3.1",
-  "devDependencies": {
-    "jquery": "~2.1.1"
-  },
   "main": "backend.js",
   "homepage": "https://github.com/callmehiphop/backend",
   "authors": [

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -19,7 +19,7 @@ module.exports = function (karma) {
     ],
 
     files: [
-      'test/bower_components/jquery/dist/jquery.js',
+      'node_modules/jquery/dist/jquery.js',
       'test/spec/*.spec.js',
       {
         pattern: 'test/fixtures/*',

--- a/lib/mocks.js
+++ b/lib/mocks.js
@@ -19,6 +19,13 @@ mocks.create = function (method, url, data, headers) {
   return stubs[stubs.length - 1];
 };
 
+mocks.remove = function (mock) {
+  var idx = mocks.indexOf(mock);
+  if (idx !== -1) {
+    mocks.splice(idx, 1);
+  }
+};
+
 /**
  * Clears out any stubs
  */

--- a/package.json
+++ b/package.json
@@ -6,23 +6,27 @@
     "test": "test"
   },
   "devDependencies": {
-    "gulp": "^3.8.8",
-    "browserify": "^6.0.3",
-    "vinyl-source-stream": "^1.0.0",
-    "karma": "^0.12.24",
-    "mocha": "^1.21.4",
-    "karma-mocha": "^0.1.9",
-    "chai": "^1.9.2",
-    "karma-chai": "^0.1.0",
-    "karma-bro": "^0.8.0",
     "brfs": "^1.2.0",
+    "browserify": "^6.0.3",
+    "chai": "^1.9.2",
+    "gulp": "^3.8.8",
+    "gulp-jshint": "^1.8.5",
+    "jquery": "~2.1.4",
+    "jshint-stylish": "^1.0.0",
+    "karma": "^0.12.24",
+    "karma-browserify": "^4.3.0",
+    "karma-chai": "^0.1.0",
+    "karma-mocha": "^0.1.9",
     "karma-phantomjs-launcher": "^0.1.4",
     "karma-spec-reporter": "0.0.13",
-    "gulp-jshint": "^1.8.5",
-    "jshint-stylish": "^1.0.0"
+    "mocha": "^1.21.4",
+    "vinyl-source-stream": "^1.0.0"
   },
   "dependencies": {
     "glob-to-regexp": "0.0.1"
+  },
+  "scripts": {
+    "test": "gulp test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
[See Travis Builds in my fork](https://travis-ci.org/nathanboktae/backend)

I moved `jquery` to npm dev dependencies so it (we) doesn't have to do a `bower install` there.

You'll still need to enable it via `Webhooks and Services` in the `Settings` menu yourself, and flip the switch on in Travis CI.