### PR TITLE
Cannot detect unmatched requests / prevent real requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## The *What*
 
-Based on AngularJS's $httpBackend, backend.js allows you to mock API responses
+Based on AngularJS's [$httpBackend](https://docs.angularjs.org/api/ngMock/service/$httpBackend), backend.js allows you to mock API responses
 in the browser. Written in vanilla JavaScript, it has 0 dependencies, so you
 should be able to use it in combination with any library and/or framework.
 
@@ -36,7 +36,7 @@ Then just require it!
 var backend = require('mocked-backend');
 ```
 
-**Note:** backend is only intended to be used within a browser, an npm option
+**Note:** backend is only intended to be used within a browser, a CJS module format
 is available for things like browserify
 
 ### bower
@@ -61,30 +61,36 @@ backend.when('GET', '/api/users/*').respond({
 });
 ```
 
-Then use XHR per usual:
-
-```javascript
-var xhr = new XMLHttpRequest();
-
-xhr.onreadystatechange = function () {
-  if (this.readyState === 4 && this.status === 200) {
-    var data = JSON.parse(xhr.responseText);
-    var msg = '<p>Hello, ' + data.name + ' the ' + data.species + '</p>';
-
-    document.body.innerHTML += msg;
-  }
-};
-
-xhr.open('GET', '/api/users/jake');
-xhr.send();
-```
-
-It also plays nicely with jQuery, so if VanillaJS isn't your thing, that's ok!
+Then use XHR or any AJAX library you wish to do your tests (jQuery with [chai](http://chaijs.com/) should assertions below):
 
 ```javascript
 $.getJSON('/api/users/jake', function (response) {
-  $('body').append('<p>Hello, ' + response.name + ' the ' + response.species + '</p>');
+  response.name.should.equal('Jake');
+  response.species.should.equal('Dog');
 });
+```
+
+Declare ajax calls you expect in your test and verify they are called ([mocha](https://mochajs.org/) and jQuery shown below):
+
+```javascript
+beforeEach(function() {
+  backend.expectPOST('/signup', {
+    username: 'Bob',
+    email: 'bob@gmail.com',
+    password: 'password'
+  }).respond(200, { userId: 3 })
+})
+
+afterEach(function() {
+  backend.verifyNoOutstandingExpectation()
+})
+
+it('should send a post to /signup when the form is filled out and completed', function() {
+  $('form.signup [name="username"]').val('Bob');
+  $('form.signup [name="email"]').val('bob@gmail.com');
+  $('form.signup [name="password"]').val('password');
+  $('form.signup [type="submit"]').click();
+})
 ```
 
 Async requests are delay by default for 100ms however you can specific a different value if you need:

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function when (expected, method, url, data, headers) {
       mock.response = new Response(status, data, headers);
     },
     passthrough: function() {
-      mock.response = 'passthrough';
+      mock.passthrough = true;
     },
     options: function(options) {
       mock.options = options;

--- a/index.js
+++ b/index.js
@@ -16,6 +16,9 @@ function when (expected, method, url, data, headers) {
     respond: function (status, data, headers) {
       mock.response = new Response(status, data, headers);
     },
+    passthrough: function() {
+      mock.response = 'passthrough';
+    },
     options: function(options) {
       mock.options = options;
       return this;

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ backend.when = _.bind(when, backend, false);
 backend.expect = _.bind(when, backend, true);
 
 _.each(['GET', 'POST', 'PUT', 'DELETE', 'PATCH'], function(method) {
-  backend['expect' + method] = _.bind(when, backend, false, method);
+  backend['expect' + method] = _.bind(when, backend, true, method);
 });
 
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -127,10 +127,18 @@ var Request = module.exports = function () {
     params = params || undefined;
 
     if (!(mock = mocks.match(method, url, params, headers))) {
-      return sendRealRequest(params);
+      var msg = 'Unexpected request: ' + method + ' ' + url;
+      if (params) {
+        msg += typeof params == 'object' ? ('\n' + JSON.stringify(params)) : params;
+      }
+      throw new Error(msg);
     }
 
-    return sendFakeRequest(params, headers);
+    if (!mock.response) {
+      throw new TypeError('No response has been defined for ' + mock.toString());
+    }
+
+    return mock.response === 'passthrough' ? sendRealRequest(params) : sendFakeRequest(params, headers);
   };
 
   /**
@@ -145,7 +153,7 @@ var Request = module.exports = function () {
    * @return {string}
    */
   this.getAllResponseHeaders = function () {
-    if (!mock) return request.getAllResponseHeaders();
+    if (mock.response === 'passthrough') return request.getAllResponseHeaders();
 
     return stringifyHeaders(mock.response.headers);
   };
@@ -156,7 +164,7 @@ var Request = module.exports = function () {
    * @return {string}
    */
   this.getResponseHeader = function (key) {
-    if (!mock) return request.getResponseHeader();
+    if (mock.response === 'passthrough') return request.getResponseHeader();
 
     return mock.response.headers[key];
   };
@@ -172,7 +180,7 @@ var Request = module.exports = function () {
    * Aborts the request!
    */
   this.abort = function () {
-    if (!mock) request.abort();
+    if (mock.response === 'passthrough') request.abort();
 
     clearTimeout(timer);
     if (this.onabort) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -134,11 +134,11 @@ var Request = module.exports = function () {
       throw new Error(msg);
     }
 
-    if (!mock.response) {
+    if (!mock.response && !mock.passthrough) {
       throw new TypeError('No response has been defined for ' + mock.toString());
     }
 
-    return mock.response === 'passthrough' ? sendRealRequest(params) : sendFakeRequest(params, headers);
+    return mock.passthrough ? sendRealRequest(params) : sendFakeRequest(params, headers);
   };
 
   /**
@@ -153,7 +153,7 @@ var Request = module.exports = function () {
    * @return {string}
    */
   this.getAllResponseHeaders = function () {
-    if (mock.response === 'passthrough') return request.getAllResponseHeaders();
+    if (mock.passthrough) return request.getAllResponseHeaders();
 
     return stringifyHeaders(mock.response.headers);
   };
@@ -164,7 +164,7 @@ var Request = module.exports = function () {
    * @return {string}
    */
   this.getResponseHeader = function (key) {
-    if (mock.response === 'passthrough') return request.getResponseHeader();
+    if (mock.passthrough) return request.getResponseHeader();
 
     return mock.response.headers[key];
   };
@@ -180,7 +180,7 @@ var Request = module.exports = function () {
    * Aborts the request!
    */
   this.abort = function () {
-    if (mock.response === 'passthrough') request.abort();
+    if (mock.passthrough) request.abort();
 
     clearTimeout(timer);
     if (this.onabort) {

--- a/test/spec/expectations.spec.js
+++ b/test/spec/expectations.spec.js
@@ -43,18 +43,52 @@ describe('expectations', function () {
   });
 
   it('should throw when verifying outstanding expectations if some were not fulfilled', function (done) {
-    backend.expect('GET', 'fixtures/data.json').respond({
-      test: 'I AM THE MACHO MAN!'
+    backend.expect('GET', 'fixtures/foo.json').respond({
+      test: 'foo'
+    });
+    backend.when('GET', 'fixtures/bar.json').respond({
+      test: 'bar'
+    });
+    backend.expectPOST('api/bas', { theanswer: 42 }).respond({
+      test: 'bas'
     });
 
-    try {
-      backend.verifyNoOutstandingExpectation();
-      done(new Error('No exceptions were thrown'));
-    } catch (e) {
-      e.should.be.instanceof(Error);
-      e.message.should.equal('Expected no outstanding expectations, but there were 1\n(expecting) GET /^fixtures\\/data\\.json$/');
-      done();
-    }
+    $.getJSON('fixtures/foo.json', function (response) {
+      response.should.be.a('object');
+      response.test.should.equal('foo');
+      $.getJSON('fixtures/bar.json', function (response) {
+        response.should.be.a('object');
+        response.test.should.equal('bar');
+
+        try {
+          backend.verifyNoOutstandingExpectation();
+          done(new Error('No exceptions were thrown'));
+        } catch (e) {
+          e.should.be.instanceof(Error);
+          e.message.should.equal('Expected no outstanding expectations, but there were 1\n' +
+            '(expecting) POST /^api\\/bas$/\n{"theanswer":42}');
+          done();
+        }
+      });
+    });
   });
 
+  it('should throw when a second attempt is made for an expectation', function (done) {
+    backend.expectGET('fixtures/data.json').respond({
+      test: 'just once'
+    });
+
+    $.getJSON('fixtures/data.json', function (response) {
+      response.should.be.a('object');
+      response.test.should.equal('just once');
+
+      $.getJSON('fixtures/data.json').then(function () {
+        done(new Error('request succeeded when it should not have'));
+      }, function(_, __, error) {
+        error.message.should.equal('Unexpected request: GET fixtures/data.json');
+        backend.verifyNoOutstandingExpectation();
+        done();
+      });
+    });
+  });
 });

--- a/test/spec/jquery.spec.js
+++ b/test/spec/jquery.spec.js
@@ -7,9 +7,10 @@ describe('backend + jQuery', function () {
   });
 
   it('should hit an end point when a stub does not exist', function (done) {
-    $.getJSON('fixtures/data.json', function (response) {
-      response.should.be.a('object');
-      response.test.should.equal('hi');
+    $.getJSON('fixtures/data.json').then(function (response) {
+      done(new Error('request should have not succeeded but it did'));
+    }, function(_, __, error) {
+      error.message.should.equal('Unexpected request: GET fixtures/data.json');
       done();
     });
   });
@@ -40,8 +41,10 @@ describe('backend + jQuery', function () {
         'X-test': 'wrong'
       },
       success: function (response) {
-        response.should.be.a('object');
-        response.test.should.equal('hi');
+        done(new Error('request should have not succeeded but it did'));
+      },
+      error: function(_, __, error) {
+        error.message.should.equal('Unexpected request: GET fixtures/data.json');
         done();
       }
     });

--- a/test/spec/jquery.spec.js
+++ b/test/spec/jquery.spec.js
@@ -6,7 +6,7 @@ describe('backend + jQuery', function () {
     backend.clear();
   });
 
-  it('should hit an end point when a stub does not exist', function (done) {
+  it('should fail when a stub does not exist', function (done) {
     $.getJSON('fixtures/data.json').then(function (response) {
       done(new Error('request should have not succeeded but it did'));
     }, function(_, __, error) {

--- a/test/spec/vanilla.spec.js
+++ b/test/spec/vanilla.spec.js
@@ -7,21 +7,17 @@ describe('backend with vanillajs', function() {
     backend.clear();
   });
 
-  it('should attempt to hit end point when mock does not exist', function() {
+  it('should throw an error when no mock has been defined for a request', function() {
     var xhr = new XMLHttpRequest();
-    var response;
 
-    xhr.onreadystatechange = function() {
-      response = xhr.response;
-    };
+    xhr.open('POST', 'api/login', false);
 
-    xhr.open('GET', 'fixtures/data.json', false);
-    xhr.send();
-
-    response.should.be.a('string');
-    response = JSON.parse(response);
-    response.should.be.a('object');
-    response.test.should.equal('hi');
+    try {
+      xhr.send({ username: 'bob', password: 'open-seasame' });
+    } catch (e) {
+      e.should.be.instanceof(Error);
+      e.message.should.equal('Unexpected request: POST api/login\n{"username":"bob","password":"open-seasame"}');
+    }
   });
 
   it('should serve up mock data when defined', function() {
@@ -45,7 +41,7 @@ describe('backend with vanillajs', function() {
     response.test.should.equal('toast is the perfect place for jelly to lay');
   });
 
-  it('should attempt to hit end point when mock exist but does not match headers', function() {
+  it('should throw an error when mock exists but does not match headers', function() {
     var xhr = new XMLHttpRequest();
     var response;
 
@@ -55,18 +51,15 @@ describe('backend with vanillajs', function() {
       test: 'toast is the perfect place for jelly to lay'
     });
 
-    xhr.onreadystatechange = function() {
-      response = xhr.response;
-    };
-
     xhr.open('GET', 'fixtures/data.json', false);
     xhr.setRequestHeader('X-test', 'wrong');
-    xhr.send();
 
-    response.should.be.a('string');
-    response = JSON.parse(response);
-    response.should.be.a('object');
-    response.test.should.equal('hi');
+    try {
+      xhr.send();
+    } catch (e) {
+      e.should.be.instanceof(Error);
+      e.message.should.equal('Unexpected request: GET fixtures/data.json');
+    }
   });
 
   it('should serve up mock data when headers do match', function() {
@@ -91,6 +84,25 @@ describe('backend with vanillajs', function() {
     response = JSON.parse(response);
     response.should.be.a('object');
     response.test.should.equal('toast is the perfect place for jelly to lay');
+  });
+
+  it('should passthrough to a real request when explicitly opted in', function() {
+    var xhr = new XMLHttpRequest();
+    var response;
+
+    backend.when('GET', 'fixtures/data.json').passthrough();
+
+    xhr.onreadystatechange = function() {
+      response = xhr.response;
+    };
+
+    xhr.open('GET', 'fixtures/data.json', false);
+    xhr.send();
+
+    response.should.be.a('string');
+    response = JSON.parse(response);
+    response.should.be.a('object');
+    response.test.should.equal('hi');
   });
 
   it('should handle async requests in an async fashion', function (done) {
@@ -160,16 +172,17 @@ describe('backend with vanillajs', function() {
   it('should not serve up mock data when params do not match', function () {
     var xhr = new XMLHttpRequest();
 
-    backend.when('GET', 'fixtures/data.json', { yes: true }).respond({
+    backend.when('POST', 'api/theanswer', { yes: true }).respond({
       test: 'bye'
     });
 
-    xhr.open('GET', 'fixtures/data.json', false);
-    xhr.send({ yes: false });
+    xhr.open('POST', 'api/theanswer', false);
 
-    expect(JSON.parse(xhr.responseText)).to.eql({
-      test: 'hi'
-    });
+    try {
+      xhr.send({ yes: false });
+    } catch (e) {
+      e.message.should.equal('Unexpected request: POST api/theanswer\n{"yes":false}');
+    }
   });
 
   it('should allow for globs', function () {

--- a/test/spec/vanilla.spec.js
+++ b/test/spec/vanilla.spec.js
@@ -17,7 +17,9 @@ describe('backend with vanillajs', function() {
     } catch (e) {
       e.should.be.instanceof(Error);
       e.message.should.equal('Unexpected request: POST api/login\n{"username":"bob","password":"open-seasame"}');
+      return;
     }
+    throw new Error('no error was thrown from send()');
   });
 
   it('should serve up mock data when defined', function() {
@@ -59,7 +61,9 @@ describe('backend with vanillajs', function() {
     } catch (e) {
       e.should.be.instanceof(Error);
       e.message.should.equal('Unexpected request: GET fixtures/data.json');
+      return;
     }
+    throw new Error('no error was thrown from send()');
   });
 
   it('should serve up mock data when headers do match', function() {
@@ -182,7 +186,9 @@ describe('backend with vanillajs', function() {
       xhr.send({ yes: false });
     } catch (e) {
       e.message.should.equal('Unexpected request: POST api/theanswer\n{"yes":false}');
+      return;
     }
+    throw new Error('no error was thrown from send()');
   });
 
   it('should allow for globs', function () {


### PR DESCRIPTION
[The code here](https://github.com/callmehiphop/backend/blob/master/lib/request.js#L129-L132) will aways send a real request when a request is not matched. This is the opposite of `$httpBackend` - it will fail if you have not mocked a request, which I think is the better way. I would prefer that real request be a whitelist - you have to explicitly opt in. Like:

```
backend.when('GET', '/some/realtime/data').passthrough()
```

Thoughts?