### PR TITLE
Default options

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,13 @@ it('should send a post to /signup when the form is filled out and completed', fu
 })
 ```
 
-Async requests are delay by default for 100ms however you can specific a different value if you need:
+Async requests are not delayed by default. However, you can specific a different value if you need:
+
+```
+backend.defaults.delay = 100;
+```
+
+and also provide per-stub delay value:
 
 ```javascript
 backend

--- a/index.js
+++ b/index.js
@@ -4,14 +4,18 @@ var Response = require('./lib/response');
 var mocks = require('./lib/mocks');
 var pending = require('./lib/pending');
 var _ = require('./lib/dash');
-var backend = module.exports = {};
+var backend = module.exports = {
+  defaults: {
+    delay: 0
+  }
+};
 
 global.XMLHttpRequest = require('./lib/request');
 
 
 function when (expected, method, url, data, headers) {
   var mock = mocks.create(method, url, data, headers, expected);
-  mock.options = {};
+  mock.options = _.extend({}, backend.defaults);
 
   return {
     respond: function (status, data, headers) {
@@ -21,7 +25,7 @@ function when (expected, method, url, data, headers) {
       mock.passthrough = true;
     },
     options: function(options) {
-      mock.options = options;
+      _.extend(mock.options, options);
       return this;
     }
   };

--- a/lib/request.js
+++ b/lib/request.js
@@ -105,7 +105,7 @@ var Request = module.exports = function () {
     pending.add(setTimeout(function() {
       pending.remove(fakeRequest);
       resolve();
-    }, mock.options.delay || 100), fakeRequest);
+    }, mock.options.delay), fakeRequest);
   }
 
   /**

--- a/test/spec/vanilla.spec.js
+++ b/test/spec/vanilla.spec.js
@@ -1,9 +1,11 @@
 var expect = require('chai').expect;
 var backend = require('../../index');
+var originalDefaults = backend.defaults;
 
 describe('backend with vanillajs', function() {
 
   afterEach(function () {
+    backend.defaults = originalDefaults;
     backend.clear();
   });
 
@@ -130,15 +132,44 @@ describe('backend with vanillajs', function() {
     expect(response).not.to.exist;
   });
 
-  it('should be able to delay the xhr call', function (done) {
+  it('should be able to delay the xhr call via defaults', function (done) {
     var startTime = new Date().getTime();
     var xhr = new XMLHttpRequest();
     var response;
 
+    backend.defaults.delay = 550;
+
+    backend
+    .when('GET', 'fixtures/data.json')
+    .respond({
+      test: 'oh my glob'
+    });
+
+    xhr.onreadystatechange = function () {
+      response = JSON.parse(xhr.responseText);
+      response.should.be.a('object');
+      response.test.should.equal('oh my glob');
+      expect(new Date().getTime() - startTime).to.be.above(500);
+      done();
+    };
+
+    xhr.open('GET', 'fixtures/data.json', true);
+    xhr.send();
+
+    expect(response).not.to.exist;
+  });
+
+  it('should be able to delay the xhr call via explicit options, overriding defaults', function (done) {
+    var startTime = new Date().getTime();
+    var xhr = new XMLHttpRequest();
+    var response;
+
+    backend.defaults.delay = 1100;
+
     backend
     .when('GET', 'fixtures/data.json')
     .options({
-      delay: 1100
+      delay: 550
     })
     .respond({
       test: 'oh my glob'
@@ -148,7 +179,7 @@ describe('backend with vanillajs', function() {
       response = JSON.parse(xhr.responseText);
       response.should.be.a('object');
       response.test.should.equal('oh my glob');
-      expect(new Date().getTime() - startTime).to.be.above(1000);
+      expect(new Date().getTime() - startTime).to.be.above(500).and.below(700);
       done();
     };
 


### PR DESCRIPTION
Support default options so that users don't have to specify a specific delay every time.

Also I changed the default delay to 0. The reasoning is that Angular's `$httpBackend` that this was modeled after was designed for unit testing, not creating a mock backend. It was focused on asserting ajax requests were made when you thought they did, with exact parameters. The need for creating a full mock API so your client code could run without a backend is better served by other libraries like [pretender](https://github.com/pretenderjs/pretender) and [xhr-interceptor](https://github.com/aaronshaf/xhr-interceptor) which are modeled after Node.js server APIs and have notions like request parameters and query string parsing. As such, the default delay should be 0 IMO.
