### PR TITLE
Fix broken passthrough requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: node_js
 sudo: false
 node_js:
   - 0.12
+before_install:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"

--- a/backend.js
+++ b/backend.js
@@ -354,9 +354,18 @@ var Request = module.exports = function () {
    * @param {*} params
    */
   function sendRealRequest (params) {
+    var resolve = fakeRequest.onreadystatechange || fakeRequest.onload || function() {};
+    delete fakeRequest.onreadystatechange;
+    delete fakeRequest.onload;
+
     request.addEventListener('readystatechange', function () {
       if (request.readyState !== 4) return;
-      _.extend(fakeRequest, _.pick(request, requestHasProp));
+      fakeRequest.readyState = 4;
+      fakeRequest.status = request.status;
+      fakeRequest.response = request.response;
+      fakeRequest.responseText = request.responseText;
+      _.extend(fakeRequest, request);
+      resolve();
     });
 
     _.extend(request, _.pick(fakeRequest, requestHasProp));

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -9,7 +9,7 @@ module.exports = function (karma) {
     logLevel: karma.LOG_ERROR,
 
     reporters: ['spec'],
-    browsers: ['UnsafePhantomJS'],
+    browsers: [process.env.TRAVIS ? 'Firefox' : 'PhantomJS'],
     plugins: ['karma-*'],
 
     frameworks: [
@@ -38,17 +38,6 @@ module.exports = function (karma) {
 
     browserify: {
       transform: ['brfs']
-    },
-
-    customLaunchers: {
-      UnsafePhantomJS: {
-        base: 'PhantomJS',
-        options: {
-          settings: {
-            webSecurityEnabled: false
-          }
-        }
-      }
     }
 
   });

--- a/lib/request.js
+++ b/lib/request.js
@@ -58,9 +58,18 @@ var Request = module.exports = function () {
    * @param {*} params
    */
   function sendRealRequest (params) {
+    var resolve = fakeRequest.onreadystatechange || fakeRequest.onload || function() {};
+    delete fakeRequest.onreadystatechange;
+    delete fakeRequest.onload;
+
     request.addEventListener('readystatechange', function () {
       if (request.readyState !== 4) return;
-      _.extend(fakeRequest, _.pick(request, requestHasProp));
+      fakeRequest.readyState = 4;
+      fakeRequest.status = request.status;
+      fakeRequest.response = request.response;
+      fakeRequest.responseText = request.responseText;
+      _.extend(fakeRequest, request);
+      resolve();
     });
 
     _.extend(request, _.pick(fakeRequest, requestHasProp));

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "karma": "^0.12.24",
     "karma-browserify": "^4.3.0",
     "karma-chai": "^0.1.0",
+    "karma-firefox-launcher": "^0.1.6",
     "karma-mocha": "^0.1.9",
     "karma-phantomjs-launcher": "^0.1.4",
     "karma-spec-reporter": "0.0.13",

--- a/test/spec/vanilla.spec.js
+++ b/test/spec/vanilla.spec.js
@@ -92,23 +92,23 @@ describe('backend with vanillajs', function() {
     response.test.should.equal('toast is the perfect place for jelly to lay');
   });
 
-  it('should passthrough to a real request when explicitly opted in', function() {
+  it('should passthrough to a real request when explicitly opted in', function(done) {
     var xhr = new XMLHttpRequest();
-    var response;
 
     backend.when('GET', 'fixtures/data.json').passthrough();
 
     xhr.onreadystatechange = function() {
-      response = xhr.response;
+      if (xhr.readyState !== 4) return;
+      var response = xhr.response;
+      response.should.be.a('string');
+      response = JSON.parse(response);
+      response.should.be.a('object');
+      response.test.should.equal('hi');
+      done();
     };
 
-    xhr.open('GET', 'fixtures/data.json', false);
+    xhr.open('GET', 'fixtures/data.json');
     xhr.send();
-
-    response.should.be.a('string');
-    response = JSON.parse(response);
-    response.should.be.a('object');
-    response.test.should.equal('hi');
   });
 
   it('should handle async requests in an async fashion', function (done) {


### PR DESCRIPTION
Real passthrough requests never worked due to readyState not being an own property in modern browsers. Yeah scary these passed in PhantomJS but not in Chrome or Firefox. I updated the CI to use Firefox in Travis to run the tests rather than PhantomJS (thanks xvfb!)
